### PR TITLE
It should use .val() to get value by jQuery. Not use .value()

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ to Vanilla JS
 From jQuery
 
 ```js
-$(<htmlElement>).value();
+$(<htmlElement>).val();
 ```
 
 to Vanilla JS
@@ -691,7 +691,7 @@ to Vanilla JS
 From jQuery
 
 ```js
-$(<htmlElement>).value(<value>);
+$(<htmlElement>).val(<value>);
 ```
 
 to Vanilla JS


### PR DESCRIPTION
As title
It should use .val() to get value by jQuery. Not use .value()

